### PR TITLE
Require documentation for private items

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ use clap::{Parser, Subcommand};
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Parser)]
 #[command(version, about)]
 pub struct Args {
+    /// The command to execute
     #[command(subcommand)]
     command: Command,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! provides a simple way to register a new GitHub App from a manifest, add the app's secrets to the
 //! .env file, and update the app when the manifest changes.
 
+#![warn(clippy::missing_docs_in_private_items)]
 #![warn(missing_docs)]
 
 use clap::Parser;


### PR DESCRIPTION
Since `github-dev-app` is developed as a binary crate, most of its code will be private. Right now, only the public command-line interface must be documented. This is not sufficient to encourage good documentation coverage, so another Clippy lint has been enabled to require documentation on private items as well.