### PR TITLE
Represent manifest for GitHub Apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,10 +82,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bstr"
@@ -97,6 +118,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -129,7 +156,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -145,6 +172,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +215,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,13 +240,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "github-dev-app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "assert_fs",
  "clap",
+ "getset",
+ "indoc",
  "predicates",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "typed-builder",
+ "typed-fields",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -182,16 +301,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -245,6 +404,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +485,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +539,18 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -316,6 +558,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -329,10 +582,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "typed-fields"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260205996a3d97400ff51124670ca15e8aad685daa5306945e517069c81e67aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "secrecy",
+ "serde",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -347,12 +645,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -427,3 +750,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,19 @@ repository = "https://github.com/otterbuild/github-dev-app"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+anyhow = "1.0.86"
 clap = { version = "4.5.7", features = ["derive"] }
+getset = "0.1.2"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
+typed-builder = "0.18.2"
+typed-fields = { version = "0.1.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0.86"
 assert_cmd = "2.0.14"
+assert_fs = "1.1.1"
+indoc = "2.0.5"
 predicates = "3.1.0"
+pretty_assertions = "1.4.0"
+tempfile = "3.10.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use clap::Parser;
 use crate::cli::Args;
 
 mod cli;
+mod manifest;
 
 fn main() {
     let _args = Args::parse();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,263 @@
+//! Manifest for a GitHub App
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, Error};
+use getset::{Getters, Setters};
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+use typed_fields::name;
+
+name!(Name);
+name!(Description);
+name!(HomepageUrl);
+name!(WebhookUrl);
+name!(RedirectUrl);
+name!(CallbackUrl);
+name!(SetupUrl);
+name!(Event);
+
+/// Manifest for a GitHub App
+///
+/// GitHub Apps can be created through GitHub's API by providing a manifest for the app. The
+/// manifest contains the configuration for the app, including its name, permissions, and callback
+/// URLs.
+///
+/// The manifest has to be provided by the user. To make customization easier, some fields in the
+/// manifest can be overwritten using command-line arguments when registering the app.
+#[derive(Clone, Eq, PartialEq, Debug, Getters, Setters, Deserialize, Serialize, TypedBuilder)]
+pub struct Manifest {
+    /// The name of the GitHub App
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub", set = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<Name>,
+
+    /// The homepage of your GitHub App
+    #[getset(get = "pub")]
+    url: HomepageUrl,
+
+    /// The configuration of the GitHub App's webhook
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hook_attributes: Option<HookAttributes>,
+
+    /// The full URL to redirect to after a user initiates the registration of a GitHub App from a
+    /// manifest
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redirect_url: Option<RedirectUrl>,
+
+    /// A full URL to redirect to after someone authorizes an installation
+    ///
+    /// Up to 10 callback URLs can be provided.
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    callback_urls: Option<Vec<CallbackUrl>>,
+
+    /// A full URL to redirect users to after they install your GitHub App if additional setup is
+    /// required
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    setup_url: Option<SetupUrl>,
+
+    /// A description of the GitHub App
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub", set = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<Description>,
+
+    /// Set to `true` when your GitHub App is available to the public or `false` when it is only
+    /// accessible to the owner of the app
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    public: Option<bool>,
+
+    /// The list of events the GitHub App subscribes to
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_events: Option<Vec<Event>>,
+
+    /// The set of permissions needed by the GitHub App
+    ///
+    /// The format of the object uses the permission name for the key (for example, issues) and the
+    /// access type for the value (for example, write).
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_permissions: Option<HashMap<String, String>>,
+
+    /// Set to `true` to request the user to authorize the GitHub App, after the GitHub App is
+    /// installed
+    #[builder(default, setter(strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub")]
+    request_oauth_on_install: Option<bool>,
+
+    /// Set to `true` to redirect users to the setup_url after they update the GitHub installation
+    #[builder(default, setter(strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub")]
+    setup_on_update: Option<bool>,
+}
+
+/// Configuration of the GitHub App's webhook
+///
+/// The webhook configuration specifies the URL of the server that will receive the webhook `POST`
+/// requests and whether the webhook is active.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, Deserialize, Serialize)]
+pub struct HookAttributes {
+    /// The URL of the server that will receive the webhook `POST` requests
+    #[getset(get = "pub")]
+    url: WebhookUrl,
+
+    /// Deliver event details when this hook is triggered, defaults to true
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active: Option<bool>,
+}
+
+impl Manifest {
+    /// Initialize a manifest from a file
+    ///
+    /// This method initializes a manifest from a file. The file is expected to contain a JSON
+    /// object that will get deserialized into a manifest.
+    #[allow(unused)] // TODO: Remove this attribute once the manifest is used
+    pub fn from_file(path: &Path) -> Result<Self, Error> {
+        let source = std::fs::read_to_string(path).context("failed to read manifest file")?;
+
+        Self::from_str(&source)
+    }
+
+    /// Initialize a manifest from a string
+    ///
+    /// This method initializes a manifest from a string. The string is expected to be a JSON object
+    /// that will get deserialized into a manifest.
+    #[allow(unused)] // TODO: Remove this attribute once the manifest is used
+    pub fn from_str(source: &str) -> Result<Self, Error> {
+        serde_json::from_str(source).context("failed to deserialize manifest")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    const JSON: &str = indoc! {r#"
+            {
+               "name": "Octoapp",
+               "url": "https://www.example.com",
+               "hook_attributes": {
+                 "url": "https://example.com/github/events"
+               },
+               "redirect_url": "https://example.com/redirect",
+               "callback_urls": [
+                 "https://example.com/callback"
+               ],
+               "public": true,
+               "default_permissions": {
+                 "issues": "write",
+                 "checks": "write"
+               },
+               "default_events": [
+                 "issues",
+                 "issue_comment",
+                 "check_suite",
+                 "check_run"
+               ]
+            }
+        "#};
+
+    #[test]
+    fn from_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(JSON.as_bytes()).unwrap();
+
+        let manifest = Manifest::from_file(file.path()).unwrap();
+
+        assert_eq!(&Some("Octoapp".into()), manifest.name());
+    }
+
+    #[test]
+    fn from_file_errors_on_empty_file() {
+        let file = NamedTempFile::new().unwrap();
+
+        let error = Manifest::from_file(file.path()).unwrap_err();
+
+        assert!(format!("{:?}", error).contains("EOF while parsing a value"));
+    }
+
+    #[test]
+    fn from_file_errors_on_missing_file() {
+        let error = Manifest::from_file(Path::new("missing.json")).unwrap_err();
+
+        assert!(format!("{:?}", error).contains("No such file or directory"));
+    }
+
+    #[test]
+    fn from_str() {
+        let manifest = Manifest::from_str(JSON).unwrap();
+
+        assert_eq!(&Some("Octoapp".into()), manifest.name());
+    }
+
+    #[test]
+    fn from_str_errors_on_invalid_json() {
+        let json = r#"{"name": "Octoapp"}"#;
+
+        let error = Manifest::from_str(json).unwrap_err();
+
+        assert!(format!("{:?}", error).contains("missing field `url`"));
+    }
+
+    #[test]
+    fn trait_deserialize() {
+        let manifest: Manifest = serde_json::from_str(JSON).unwrap();
+
+        assert_eq!(&Some("Octoapp".into()), manifest.name());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Manifest>();
+    }
+
+    #[test]
+    fn trait_serialize() {
+        let manifest = Manifest::builder()
+            .url("https://www.example.com".into())
+            .build();
+
+        let expected = r#"{"url":"https://www.example.com"}"#;
+
+        let json = serde_json::to_string(&manifest).unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Manifest>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Manifest>();
+    }
+}


### PR DESCRIPTION
A new struct has been created that represents the manifest for a GitHub App[^1]. The intention is that the user provides the path to the manifest, which is then read from the file and parsed. Some fields can be overwritten by the user, for example the name of the app. Most fields are read-only, though, since we want to encourage good defaults in the shared manifest and little customization on-the-fly.

[^1]: https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest#github-app-manifest-parameters