### PR TITLE
Bootstrap command to register a GitHub App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,18 +97,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_fs"
-version = "1.1.1"
+name = "async-trait"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -101,6 +112,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -118,6 +144,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "cfg-if"
@@ -170,31 +202,6 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "diff"
@@ -252,12 +259,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "github-dev-app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "assert_fs",
+ "async-trait",
  "clap",
  "getset",
  "indoc",
@@ -266,32 +279,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "typed-builder",
  "typed-fields",
-]
-
-[[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags",
- "ignore",
- "walkdir",
 ]
 
 [[package]]
@@ -301,20 +291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "ignore"
-version = "0.4.22"
+name = "hermit-abi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "indoc"
@@ -347,16 +327,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "log"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -372,6 +355,31 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "predicates"
@@ -485,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,15 +516,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "secrecy"
@@ -600,6 +605,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "tokio"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+dependencies = [
+ "backtrace",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,25 +685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,17 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.86"
+async-trait = "0.1.80"
 clap = { version = "4.5.7", features = ["derive"] }
 getset = "0.1.2"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 typed-builder = "0.18.2"
 typed-fields = { version = "0.1.0", features = ["serde"] }
 
 [dev-dependencies]
-anyhow = "1.0.86"
 assert_cmd = "2.0.14"
-assert_fs = "1.1.1"
 indoc = "2.0.5"
 predicates = "3.1.0"
 pretty_assertions = "1.4.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,17 +5,21 @@
 //! from the comments on the `Args` struct.
 
 use clap::{Parser, Subcommand};
+use getset::Getters;
+
+use crate::register::RegisterArgs;
 
 /// Create and manage a GitHub App for local development
 ///
 /// This command-line tool can be used to create and manage a GitHub App for local development. It
 /// provides a simple way to register a new GitHub App from a manifest, add the app's secrets to the
 /// .env file, and update the app when the manifest changes.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Parser)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Parser, Getters)]
 #[command(version, about)]
 pub struct Args {
     /// The command to execute
     #[command(subcommand)]
+    #[getset(get = "pub")]
     command: Command,
 }
 
@@ -23,8 +27,11 @@ pub struct Args {
 ///
 /// The `github-dev-app` command-line tool supports the top-level commands in this enum. Each
 /// command has its own set of arguments and options that can be used to customize its behavior.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
-pub enum Command {}
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
+pub enum Command {
+    /// Register a new GitHub App using a manifest file
+    Register(RegisterArgs),
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,33 @@
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(missing_docs)]
 
+use anyhow::Error;
+use async_trait::async_trait;
 use clap::Parser;
 
-use crate::cli::Args;
+use crate::cli::{Args, Command};
+use crate::register::RegisterCommand;
 
 mod cli;
 mod manifest;
+mod register;
 
-fn main() {
-    let _args = Args::parse();
+/// Execute a command
+///
+/// This trait must be implemented by the subcommands of the command-line tool. It provides a single
+/// method, `execute`, that will be called by the main function to run the command.
+#[async_trait]
+trait Execute {
+    async fn execute(&self, global_args: &Args) -> Result<(), Error>;
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let global_args = Args::parse();
+
+    let command: Box<dyn Execute> = match global_args.command() {
+        Command::Register(args) => Box::new(RegisterCommand::new(args)),
+    };
+
+    command.execute(&global_args).await
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -129,7 +129,6 @@ impl Manifest {
     ///
     /// This method initializes a manifest from a file. The file is expected to contain a JSON
     /// object that will get deserialized into a manifest.
-    #[allow(unused)] // TODO: Remove this attribute once the manifest is used
     pub fn from_file(path: &Path) -> Result<Self, Error> {
         let source = std::fs::read_to_string(path).context("failed to read manifest file")?;
 
@@ -140,7 +139,6 @@ impl Manifest {
     ///
     /// This method initializes a manifest from a string. The string is expected to be a JSON object
     /// that will get deserialized into a manifest.
-    #[allow(unused)] // TODO: Remove this attribute once the manifest is used
     pub fn from_str(source: &str) -> Result<Self, Error> {
         serde_json::from_str(source).context("failed to deserialize manifest")
     }

--- a/src/register/args.rs
+++ b/src/register/args.rs
@@ -1,0 +1,19 @@
+//! Command-line arguments for the `register` subcommand
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use getset::Getters;
+
+/// Command-line arguments for the `register` subcommand
+///
+/// The `register` subcommand is used to register a new GitHub App from a manifest file. The command
+/// requires the path to the manifest file as an argument, and optionally accepts other arguments to
+/// customize the manifest.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Parser, Getters)]
+pub struct RegisterArgs {
+    /// The path to the manifest file
+    #[arg()]
+    #[getset(get = "pub")]
+    manifest: PathBuf,
+}

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -1,0 +1,38 @@
+//! Command to register a new GitHub App
+
+use anyhow::Error;
+use async_trait::async_trait;
+
+use crate::cli::Args;
+use crate::manifest::Manifest;
+use crate::register::RegisterArgs;
+use crate::Execute;
+
+/// Register a new GitHub App
+///
+/// This command is used to register a new GitHub App from a manifest file. The manifest file must
+/// be provided as an argument to the command. The command will parse the manifest, optionally
+/// customize it, and then register the app with GitHub.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct RegisterCommand<'a> {
+    /// The arguments for the command
+    args: &'a RegisterArgs,
+}
+
+impl<'a> RegisterCommand<'a> {
+    /// Create a new instance of the command
+    pub fn new(args: &'a RegisterArgs) -> Self {
+        Self { args }
+    }
+}
+
+#[async_trait]
+impl<'a> Execute for RegisterCommand<'a> {
+    async fn execute(&self, _global_args: &Args) -> Result<(), Error> {
+        let manifest = Manifest::from_file(self.args.manifest())?;
+
+        println!("{}", serde_json::to_string(&manifest)?);
+
+        Ok(())
+    }
+}

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,0 +1,7 @@
+//! Register a new GitHub App from a manifest
+
+pub use self::args::*;
+pub use self::command::*;
+
+mod args;
+mod command;

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+use anyhow::Error;
+use assert_cmd::prelude::*;
+use tempfile::NamedTempFile;
+
+#[test]
+fn prints_manifest() -> Result<(), Error> {
+    let mut command = Command::cargo_bin("github-dev-app")?;
+
+    let manifest = NamedTempFile::new()?;
+    std::fs::write(manifest.path(), r#"{"url":"http://localhost"}"#)?;
+
+    command.arg("register").arg(manifest.path());
+
+    command
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("http://localhost"));
+
+    Ok(())
+}


### PR DESCRIPTION
The initial structure for commands has been created, using the `register` command as an example. The command will allow users to register a new GitHub App from a manifest file. At this point, the command does nothing more than read a manifest file, parse it, and print it as JSON to the terminal.