### PR TITLE
Pass a port for the web server as an option

### DIFF
--- a/src/register/args.rs
+++ b/src/register/args.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use getset::Getters;
+use getset::{CopyGetters, Getters};
 use typed_builder::TypedBuilder;
 
 /// Command-line arguments for the `register` subcommand
@@ -12,7 +12,18 @@ use typed_builder::TypedBuilder;
 /// requires the path to the manifest file as an argument, and optionally accepts other arguments to
 /// customize the manifest.
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Parser, Getters, TypedBuilder,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Default,
+    Parser,
+    CopyGetters,
+    Getters,
+    TypedBuilder,
 )]
 pub struct RegisterArgs {
     /// The path to the manifest file
@@ -20,4 +31,10 @@ pub struct RegisterArgs {
     #[builder(setter(into))]
     #[getset(get = "pub")]
     manifest: PathBuf,
+
+    /// The port used by the embedded web server
+    #[arg(long)]
+    #[builder(setter(into))]
+    #[getset(get_copy = "pub")]
+    port: Option<u16>,
 }

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -50,7 +50,8 @@ impl<'a> RegisterCommand<'a> {
 #[async_trait]
 impl<'a> Execute for RegisterCommand<'a> {
     async fn execute(&self, _global_args: &Args) -> Result<(), Error> {
-        let (addr, _receiver) = start_background_web_server(self.args.manifest()).await?;
+        let (addr, _receiver) =
+            start_background_web_server(self.args.manifest(), self.args.port()).await?;
 
         // Open a browser to start the registration process
         self.open_registration_form(&addr)?;


### PR DESCRIPTION
A new option has been added to the command-line interface for the `register` command that can be used to set the port for the embedded web server. This options is mostly required for the integration tests.