### PR TITLE
Wait for temporary code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "getset",
  "indoc",
  "open",
+ "port_check",
  "predicates",
  "pretty_assertions",
  "reqwest",
@@ -1036,6 +1037,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "port_check"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2110609fb863cdb367d4e69d6c43c81ba6a8c7d18e80082fe9f3ef16b23afeed"
 
 [[package]]
 name = "predicates"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ typed-fields = { version = "0.1.0", features = ["serde"] }
 [dev-dependencies]
 assert_cmd = "2.0.14"
 indoc = "2.0.5"
+port_check = "0.2.1"
 predicates = "3.1.0"
 pretty_assertions = "1.4.0"
 tempfile = "3.10.1"

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -2,11 +2,9 @@
 
 use std::env::var;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::time::Duration;
 
 use anyhow::{Context, Error};
 use async_trait::async_trait;
-use tokio::time::sleep;
 
 use crate::cli::Args;
 use crate::register::server::start_background_web_server;
@@ -65,14 +63,14 @@ fn replace_localhost(addr: &SocketAddr) -> String {
 #[async_trait]
 impl<'a> Execute for RegisterCommand<'a> {
     async fn execute(&self, _global_args: &Args) -> Result<(), Error> {
-        let (addr, _receiver) =
+        let (addr, mut receiver) =
             start_background_web_server(self.args.manifest(), self.args.port()).await?;
 
         // Open a browser to start the registration process
         self.open_registration_form(&addr)?;
 
-        // Wait for browser to open
-        sleep(Duration::from_secs(10)).await;
+        // Wait for the user to be redirected back to the local server with a temporary code
+        let _temporary_code = receiver.recv().await;
 
         Ok(())
     }

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -1,19 +1,49 @@
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::Error;
 use assert_cmd::prelude::*;
+use port_check::is_port_reachable;
+use reqwest::Client;
 use tempfile::NamedTempFile;
+use tokio::time::sleep;
 
-#[test]
-fn prints_manifest() -> Result<(), Error> {
+#[tokio::test]
+async fn saves_private_key_and_secrets() -> Result<(), Error> {
     let mut command = Command::cargo_bin("github-dev-app")?;
 
+    // Create a temporary manifest file
     let manifest = NamedTempFile::new()?;
     std::fs::write(manifest.path(), r#"{"url":"http://localhost"}"#)?;
 
-    command.arg("register").arg(manifest.path());
+    // Execute the register command
+    let mut process_handle = command
+        .arg("register")
+        .arg(manifest.path())
+        .arg("--port")
+        .arg("64001")
+        .spawn()
+        .expect("failed to execute command");
 
-    command.assert().success();
+    // Wait for server to launch
+    for _ in 0..10 {
+        if is_port_reachable("localhost:64001") {
+            break;
+        } else {
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    // Send temporary code
+    Client::new()
+        .post("http://localhost:64001/callback?code=otters-are-the-cutest")
+        .send()
+        .await
+        .expect("failed to send temporary code");
+
+    let exit_status = process_handle.wait().expect("failed to wait for command");
+
+    assert!(exit_status.success());
 
     Ok(())
 }


### PR DESCRIPTION
After opening the form to register a new GitHub App, the local web server now waits for the temporary code. Once the code is received, it is sent to the main thread through a channel.