### PR TITLE
Add option to set GitHub API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "tokio",
  "typed-builder",
  "typed-fields",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.117"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 typed-builder = "0.19.0"
 typed-fields = { version = "0.1.0", features = ["serde"] }
+url = "2.5.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/register/args.rs
+++ b/src/register/args.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use getset::{CopyGetters, Getters};
 use typed_builder::TypedBuilder;
+use url::Url;
 
 /// Command-line arguments for the `register` subcommand
 ///
@@ -12,18 +13,7 @@ use typed_builder::TypedBuilder;
 /// requires the path to the manifest file as an argument, and optionally accepts other arguments to
 /// customize the manifest.
 #[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    Default,
-    Parser,
-    CopyGetters,
-    Getters,
-    TypedBuilder,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Parser, CopyGetters, Getters, TypedBuilder,
 )]
 pub struct RegisterArgs {
     /// The path to the manifest file
@@ -31,6 +21,12 @@ pub struct RegisterArgs {
     #[builder(setter(into))]
     #[getset(get = "pub")]
     manifest: PathBuf,
+
+    /// The endpoint of the GitHub API
+    #[arg(long, default_value_t = Url::parse("https://api.github.com").unwrap())]
+    #[builder(setter(into))]
+    #[getset(get = "pub")]
+    github: Url,
 
     /// The port used by the embedded web server
     #[arg(long)]

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -63,8 +63,12 @@ fn replace_localhost(addr: &SocketAddr) -> String {
 #[async_trait]
 impl<'a> Execute for RegisterCommand<'a> {
     async fn execute(&self, _global_args: &Args) -> Result<(), Error> {
-        let (addr, mut receiver) =
-            start_background_web_server(self.args.manifest(), self.args.port()).await?;
+        let (addr, mut receiver) = start_background_web_server(
+            self.args.manifest(),
+            self.args.github().clone(),
+            self.args.port(),
+        )
+        .await?;
 
         // Open a browser to start the registration process
         self.open_registration_form(&addr)?;

--- a/src/register/form.rs
+++ b/src/register/form.rs
@@ -1,6 +1,7 @@
 //! The form for starting the registration process
 
 use askama_axum::Template;
+use url::Url;
 
 use crate::manifest::SerializedManifest;
 
@@ -12,13 +13,16 @@ use crate::manifest::SerializedManifest;
 #[derive(Clone, Eq, PartialEq, Debug, Template)]
 #[template(path = "form.html", escape = "none")]
 pub struct Form {
+    /// The endpoint of the GitHub API
+    github: Url,
+
     /// The manifest for the GitHub App
     manifest: SerializedManifest,
 }
 
 impl Form {
     /// Create a new instance of the form
-    pub fn new(manifest: SerializedManifest) -> Self {
-        Self { manifest }
+    pub fn new(github: Url, manifest: SerializedManifest) -> Self {
+        Self { github, manifest }
     }
 }

--- a/templates/form.html
+++ b/templates/form.html
@@ -14,7 +14,7 @@
       registration process.
     </p>
 
-    <form action="https://github.com/settings/apps/new" method="post">
+    <form action="{{ github }}/settings/apps/new" method="post">
       <input type="hidden" name="manifest" id="manifest" /><br />
       <input type="submit" value="Create GitHub App" />
     </form>


### PR DESCRIPTION
A new option has been added to the `register` command that can be used to set the URL of the GitHub API. This is useful in tests and for customers with self-hosted GitHub Enterprise Servers.