### PR TITLE
Fix endpoint for registration form

### DIFF
--- a/src/register/form.rs
+++ b/src/register/form.rs
@@ -14,7 +14,7 @@ use crate::manifest::SerializedManifest;
 #[template(path = "form.html", escape = "none")]
 pub struct Form {
     /// The endpoint of the GitHub API
-    github: Url,
+    form_endpoint: Url,
 
     /// The manifest for the GitHub App
     manifest: SerializedManifest,
@@ -23,6 +23,19 @@ pub struct Form {
 impl Form {
     /// Create a new instance of the form
     pub fn new(github: Url, manifest: SerializedManifest) -> Self {
-        Self { github, manifest }
+        let base_url = if github.domain() == Some("api.github.com") {
+            Url::parse("https://github.com").expect("failed to parse hard-coded URL")
+        } else {
+            github
+        };
+
+        let form_endpoint = base_url
+            .join("/settings/apps/new")
+            .expect("failed to parse hard-coded URL path");
+
+        Self {
+            form_endpoint,
+            manifest,
+        }
     }
 }

--- a/templates/form.html
+++ b/templates/form.html
@@ -16,15 +16,11 @@
             <p>
               Click the button below to register a new GitHub App for local
               development. You will be redirected to GitHub, where you can
-              choose a unique name for the app. Afterwards, you will be
+              choose a unique name for the app. Afterward, you will be
               redirected back to complete the registration process.
             </p>
           </div>
-          <form
-            action="{{ github }}/settings/apps/new"
-            method="post"
-            class="mb-0"
-          >
+          <form action="{{ form_endpoint }}" method="post" class="mb-0">
             <input type="hidden" name="manifest" id="manifest" /><br />
             <input
               type="submit"


### PR DESCRIPTION
After the changes in #25, which allowed to provide a custom endpoint for GitHub, the registration form could not be sent successfully anymore. One reason was that the path was not added correctly to the base URL, but the bigger problem was that GitHub uses different domains for its hosted web interface and API. This is in contrast to self-hosted instances, where the API is served from a different path (`/api`) and not a different subdomain (`api.github.com`).