### PR TITLE
Listen on internal IP address

### DIFF
--- a/src/register/server.rs
+++ b/src/register/server.rs
@@ -56,7 +56,7 @@ pub async fn start_background_web_server(
     port: Option<u16>,
 ) -> Result<(SocketAddr, Receiver<String>), Error> {
     // Either use the given port or let the OS choose a random port
-    let interface = format!("0.0.0.0:{}", port.unwrap_or(0));
+    let interface = format!("127.0.0.1:{}", port.unwrap_or(0));
     let listener = TcpListener::bind(interface.parse::<SocketAddr>().unwrap()).await?;
     let addr = listener.local_addr()?;
 


### PR DESCRIPTION
The embedded web server has been tweaked to launch on an local IP address to avoid warnings in the browser. Previously, the local IP was replaced by the domain `localhost` for the registration form. But this fix hadn't been applied for the callback , which ended up failing due to warnings in the browser. Instead, we are now listening on a local-only IP address, which should avoid th warnings in most (if not all) modern browsers.