### PR TITLE
Fix HTTP method for callback

### DIFF
--- a/src/register/server.rs
+++ b/src/register/server.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::{Context, Error};
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
-use axum::routing::{get, post};
+use axum::routing::get;
 use axum::Router;
 use serde::Deserialize;
 use tokio::net::TcpListener;
@@ -99,7 +99,7 @@ async fn run_axum_server(
 ) -> Result<(), Error> {
     let app = Router::new()
         .route("/", get(show_form))
-        .route("/callback", post(accept_temporary_code))
+        .route("/callback", get(accept_temporary_code))
         .with_state(AppState {
             channel,
             github,
@@ -225,13 +225,13 @@ mod tests {
         .unwrap();
 
         let _response = Client::new()
-            .post(format!(
+            .get(format!(
                 "http://{}/callback?code=otters-are-the-cutest",
                 addr
             ))
             .send()
             .await
-            .expect("failed to execute POST /callback request");
+            .expect("failed to execute GET /callback request");
 
         assert_eq!(Some("otters-are-the-cutest".into()), receiver.recv().await);
     }

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -66,7 +66,7 @@ async fn saves_private_key_and_secrets() -> Result<(), Error> {
 
     // Send temporary code
     Client::new()
-        .post("http://localhost:64001/callback?code=otters-are-the-cutest")
+        .get("http://localhost:64001/callback?code=otters-are-the-cutest")
         .send()
         .await
         .expect("failed to send temporary code");


### PR DESCRIPTION
After registering a new app, GitHub redirects the user back to the local web server. This redirect is done using a `GET` request, but we accidentally expected a `POST` request.