### PR TITLE
Make webhook secret an optional field

### DIFF
--- a/src/register/app.rs
+++ b/src/register/app.rs
@@ -36,9 +36,9 @@ pub struct App {
     client_secret: ClientSecret,
 
     /// The webhook secret for the app
-    #[cfg_attr(test, builder(setter(into)))]
+    #[cfg_attr(test, builder(setter(into, strip_option)))]
     #[getset(get = "pub")]
-    webhook_secret: WebhookSecret,
+    webhook_secret: Option<WebhookSecret>,
 
     /// The private key for the app
     #[cfg_attr(test, builder(setter(into)))]

--- a/src/register/env.rs
+++ b/src/register/env.rs
@@ -68,10 +68,14 @@ fn update_env(old_env: &str, app: &App) -> String {
         "GITHUB_CLIENT_SECRET={}\n",
         app.client_secret().expose()
     ));
-    new_env.push_str(&format!(
-        "GITHUB_WEBHOOK_SECRET={}\n",
-        app.webhook_secret().expose()
-    ));
+
+    if let Some(webhook_secret) = app.webhook_secret() {
+        new_env.push_str(&format!(
+            "GITHUB_WEBHOOK_SECRET={}\n",
+            webhook_secret.expose()
+        ));
+    }
+
     new_env.push_str(&format!(
         "GITHUB_PRIVATE_KEY=\"{}\"\n",
         app.pem().expose().escape_default()


### PR DESCRIPTION
If the manifest does not include any webhooks, the app conversion will not contain a webhook secret.