### PR TITLE
Open the installations page after registration

### DIFF
--- a/src/register/app.rs
+++ b/src/register/app.rs
@@ -7,6 +7,7 @@ use typed_builder::TypedBuilder;
 use typed_fields::{name, number, secret};
 
 number!(Id);
+name!(Name);
 name!(ClientId);
 secret!(ClientSecret);
 secret!(WebhookSecret);
@@ -24,6 +25,11 @@ pub struct App {
     #[cfg_attr(test, builder(setter(into)))]
     #[getset(get_copy = "pub")]
     id: Id,
+
+    /// The unique name for the app
+    #[cfg_attr(test, builder(setter(into)))]
+    #[getset(get = "pub")]
+    name: Name,
 
     /// The client ID for the app
     #[cfg_attr(test, builder(setter(into)))]

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -48,6 +48,23 @@ impl<'a> RegisterCommand<'a> {
         open::that(format!("http://{}:{}", addr.ip(), addr.port()))
             .context("failed to open browser to start registration process")
     }
+
+    /// Open the page to install the app
+    ///
+    /// After a new app has been registered, the user can install it in their GitHub account. This
+    /// method opens the GitHub settings to install the app.
+    fn open_installation_page(&self, app: &App) -> Result<(), Error> {
+        // Skip opening the browser if running in CI
+        if var("CI").is_ok() {
+            return Ok(());
+        }
+
+        open::that(format!(
+            "https://github.com/settings/apps/{}/installations",
+            app.name()
+        ))
+        .context("failed to open browser to start installation process")
+    }
 }
 
 #[async_trait]
@@ -74,6 +91,9 @@ impl<'a> Execute for RegisterCommand<'a> {
 
         // Save secrets and private key to the .env file
         save_to_env(&app)?;
+
+        // Open the page to install the app
+        self.open_installation_page(&app)?;
 
         Ok(())
     }

--- a/src/register/env.rs
+++ b/src/register/env.rs
@@ -43,6 +43,7 @@ fn update_env(old_env: &str, app: &App) -> String {
         .filter(|line| {
             for variable in [
                 "GITHUB_APP_ID",
+                "GITHUB_APP_NAME",
                 "GITHUB_CLIENT_ID",
                 "GITHUB_CLIENT_SECRET",
                 "GITHUB_WEBHOOK_SECRET",
@@ -63,6 +64,7 @@ fn update_env(old_env: &str, app: &App) -> String {
     }
 
     new_env.push_str(&format!("GITHUB_APP_ID={}\n", app.id()));
+    new_env.push_str(&format!("GITHUB_APP_NAME={}\n", app.name()));
     new_env.push_str(&format!("GITHUB_CLIENT_ID=\"{}\"\n", app.client_id()));
     new_env.push_str(&format!(
         "GITHUB_CLIENT_SECRET={}\n",
@@ -100,6 +102,7 @@ mod tests {
 
         let app = App::builder()
             .id(1)
+            .name("app")
             .client_id("client_id")
             .client_secret("client_secret")
             .webhook_secret("webhook_secret")
@@ -112,6 +115,7 @@ mod tests {
             indoc! {r#"
             DATABASE_URL=postgres://localhost/db
             GITHUB_APP_ID=1
+            GITHUB_APP_NAME=app
             GITHUB_CLIENT_ID="client_id"
             GITHUB_CLIENT_SECRET=client_secret
             GITHUB_WEBHOOK_SECRET=webhook_secret

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -36,6 +36,7 @@ async fn saves_private_key_and_secrets() -> Result<(), Error> {
         .with_body(indoc! {r#"
             {
               "id": 1,
+              "name": "github-dev-app",
               "client_id": "Iv1.8a61f9b3a7aba766",
               "client_secret": "1726be1638095a19edd134c77bde3aa2ece1e5d8",
               "webhook_secret": "e340154128314309424b7c8e90325147d99fdafa",
@@ -84,6 +85,7 @@ async fn saves_private_key_and_secrets() -> Result<(), Error> {
     assert_eq!(
         indoc! {r#"
         GITHUB_APP_ID=1
+        GITHUB_APP_NAME=github-dev-app
         GITHUB_CLIENT_ID="Iv1.8a61f9b3a7aba766"
         GITHUB_CLIENT_SECRET=1726be1638095a19edd134c77bde3aa2ece1e5d8
         GITHUB_WEBHOOK_SECRET=e340154128314309424b7c8e90325147d99fdafa


### PR DESCRIPTION
After the user has successfully registered the new GitHub App, the page that lists the app's installations is opened. This makes it easy for the user to install the app in his personal GitHub account.